### PR TITLE
pmdファイル読み込み実装　ヘッダー情報読み込み

### DIFF
--- a/New Unity Project/Assets/MMDLoader.meta
+++ b/New Unity Project/Assets/MMDLoader.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2bb5809d9f802cb439a60120f6abcacc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/MMDLoader/MMDLoader.cs
+++ b/New Unity Project/Assets/MMDLoader/MMDLoader.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+
+public class MMDLoader : MonoBehaviour
+{
+    /// <summary>
+    /// pmdファイル名
+    /// </summary>
+    string fileName = "/Lat式ミクver2.31/Lat式ミクVer2.31_Normal.pmd";
+
+    /// <summary>
+    /// ヘッダー情報クラス
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    private class HEADER
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+        char[] magic; // "Pmd"
+        float version; // 00 00 80 3F == 1.00 // 訂正しました。コメントありがとうございます
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+        char[] model_name;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 256)]
+        char[] comment;
+    };
+
+
+    /// <summary>
+    /// ヘッダー読み込み
+    /// </summary>
+    void ReadHeader()
+    {
+        FileStream fs = new FileStream(Application.dataPath+ fileName, FileMode.Open, FileAccess.Read);
+        HEADER header;
+        int count = Marshal.SizeOf(typeof(HEADER));
+        byte[] readBuffer = new byte[count];
+        BinaryReader reader = new BinaryReader(fs);
+        readBuffer = reader.ReadBytes(count);
+        GCHandle handle = GCHandle.Alloc(readBuffer, GCHandleType.Pinned);
+        header = (HEADER)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(HEADER));
+        handle.Free();
+        fs.Dispose();
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        ReadHeader();
+    }
+
+}

--- a/New Unity Project/Assets/MMDLoader/MMDLoader.cs.meta
+++ b/New Unity Project/Assets/MMDLoader/MMDLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bdbce5cf1fe4eaa4fa2efc35ed2c7555
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
pmdファイルのヘッダーを読み込む実装をしました。
ヘッダーは以下の構造体になっています。

```
char magic[3]; // "Pmd"
float version; // 00 00 80 3F == 1.00 // 訂正しました。コメントありがとうございます
char model_name[20];
char comment[256];

```
