### PR TITLE
マテリアル読み込み及びメッシュに貼り付け処理実装

### DIFF
--- a/New Unity Project/Assets/MMDLoader/MMDLoader.cs
+++ b/New Unity Project/Assets/MMDLoader/MMDLoader.cs
@@ -42,6 +42,34 @@ public class t_vertex
     public byte edge_flag; // 0:通常、1:エッジ無効 // エッジ(輪郭)が有効の場合
 };
 
+/// <summary>
+/// ヘッダー情報クラス
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public class t_material
+{
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+    public float[] diffuse_color; // dr, dg, db // 減衰色
+
+    public float alpha; // 減衰色の不透明度
+    public float specularity;
+
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+    public float[] specular_color; // sr, sg, sb // 光沢色
+
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+    public float[] mirror_color; // mr, mg, mb // 環境色(ambient)
+
+    public byte toon_index; // toon??.bmp // 0.bmp:0xFF, 1(01).bmp:0x00 ・・・ 10.bmp:0x09
+    public byte edge_flag; // 輪郭、影
+    public uint face_vert_count; // 面頂点数 // 面数ではありません。この材質で使う、面頂点リストのデータ数です。
+
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+    public char[] texture_file_name; // テクスチャファイル名またはスフィアファイル名 // 20バイトぎりぎりまで使える(終端の0x00は無くても動く)
+
+};
+
+
 public class MMDLoader : MonoBehaviour
 {
     FileStream fileStream;
@@ -57,6 +85,8 @@ public class MMDLoader : MonoBehaviour
     List<t_vertex> tVertexList = new List<t_vertex>(); // 頂点データ(38Bytes/頂点)
     uint face_vert_count; // 頂点数 // 面数ではありません
     List<int> face_vert_index = new List<int>(); // 頂点番号(3個/面)
+    uint material_count; // 材質数
+    List<t_material> tMaterialiList = new List<t_material>();
 
 
     /// <summary>
@@ -94,12 +124,14 @@ public class MMDLoader : MonoBehaviour
             handle = GCHandle.Alloc(readBuffer, GCHandleType.Pinned);
             t_vertex tVertex = (t_vertex)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(t_vertex));
             tVertexList.Add(tVertex);
-            Debug.Log(tVertex.pos[0] + ", " + tVertex.pos[1] + ", " + tVertex.pos[2]);
         }
 
         handle.Free();
     }
 
+    /// <summary>
+    /// 面情報読み込み
+    /// </summary>
     void ReadFace()
     {
         int count = Marshal.SizeOf(typeof(uint));
@@ -123,24 +155,83 @@ public class MMDLoader : MonoBehaviour
         handle.Free();
     }
 
-    void DrawMesh()
+    /// <summary>
+    /// マテリアルリスト読み込み
+    /// </summary>
+    void ReadMaterial()
     {
+        int count = Marshal.SizeOf(typeof(uint));
+        byte[] readBuffer = new byte[count];
+        BinaryReader reader = new BinaryReader(fileStream);
+        readBuffer = reader.ReadBytes(count);
+        GCHandle handle = GCHandle.Alloc(readBuffer, GCHandleType.Pinned);
+        material_count = (uint)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(uint));
+
+        for (int i = 0; i < material_count; i++)
+        {
+            count = Marshal.SizeOf(typeof(t_material));
+            readBuffer = new byte[count];
+            reader = new BinaryReader(fileStream);
+            readBuffer = reader.ReadBytes(count);
+            handle = GCHandle.Alloc(readBuffer, GCHandleType.Pinned);
+            t_material tMateriali = (t_material)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(t_material));
+            string textureFileName = "";
+            for (int j = 0; j < 20; j++)
+            {
+                textureFileName += tMateriali.texture_file_name[j];
+            }
+            UnityEngine.Debug.Log(textureFileName);
+            tMaterialiList.Add(tMateriali);
+        }
+    }
+
+    void DrawMesh(int offsetPos, int faceVertCount, string textureName)
+    {
+        GameObject obj = new GameObject();
+        obj.transform.parent = this.transform;
+        obj.transform.localScale = Vector3.one;
+        obj.AddComponent<MeshRenderer>();
+        obj.AddComponent<MeshFilter>();
+
         Mesh mesh = new Mesh();
 
         // 頂点リストを作成
         List<Vector3> vertices = new List<Vector3>();
+        List<Vector2> uvList = new List<Vector2>();
 
-        foreach(t_vertex t_Vertex in tVertexList)
+        int i = 0;
+
+        foreach (t_vertex t_Vertex in tVertexList)
         {
             Vector3 vertex = new Vector3(t_Vertex.pos[0], t_Vertex.pos[1], t_Vertex.pos[2]);
             vertices.Add(vertex);
+
+            Vector3 uv = new Vector3(t_Vertex.uv[0], t_Vertex.uv[1]);
+
+            uvList.Add(uv);
         }
 
+        List<int> facevertList = new List<int>();
+        for(i = offsetPos; i < offsetPos + faceVertCount; i++)
+        {
+            facevertList.Add(face_vert_index[i]);
+        }
         mesh.SetVertices(vertices);
-        mesh.SetTriangles(face_vert_index, 0);
-        MeshFilter meshFilter = GetComponent<MeshFilter>();
+        mesh.SetUVs(0, uvList);
+        mesh.SetTriangles(facevertList, 0);
+        MeshFilter meshFilter = obj.GetComponent<MeshFilter>();
+
+        Texture J_SEIKAI01;
+        string fileName = textureName.Split('*')[0];
+        fileName = fileName.Split('.')[0];
+        J_SEIKAI01 = Resources.Load("lat/"+fileName) as Texture;
+        obj.GetComponent<Renderer>().material.shader = Shader.Find("Unlit/Texture");
+        obj.name = fileName;
+        obj.GetComponent<Renderer>().material.SetTexture("_MainTex", J_SEIKAI01);
+
         meshFilter.mesh = mesh;
     }
+
 
     // Start is called before the first frame update
     void Start()
@@ -149,9 +240,16 @@ public class MMDLoader : MonoBehaviour
         ReadHeader();
         ReadVertexList();
         ReadFace();
+        ReadMaterial();
         fileStream.Dispose();
 
-        DrawMesh();
+        int offsetPos = 0;
+
+        foreach(t_material tMaterial in tMaterialiList)
+        {
+            DrawMesh(offsetPos, (int)tMaterial.face_vert_count, new string(tMaterial.texture_file_name));
+            offsetPos += (int)tMaterial.face_vert_count;
+        }
     }
 
 }

--- a/New Unity Project/Assets/MMDLoader/MMDLoader.cs
+++ b/New Unity Project/Assets/MMDLoader/MMDLoader.cs
@@ -187,51 +187,60 @@ public class MMDLoader : MonoBehaviour
 
     void DrawMesh(int offsetPos, int faceVertCount, string textureName)
     {
+        // 頂点リストを作成
+        List<Vector3> vertices = new List<Vector3>();
+        List<Vector2> uvList = new List<Vector2>();
+        List<int> facevertList = new List<int>();
+        int faceVertIndex = 0;
+        Mesh mesh = new Mesh();
+
+        //メッシュ用ゲームオブジェクト生成
         GameObject obj = new GameObject();
         obj.transform.parent = this.transform;
         obj.transform.localScale = Vector3.one;
         obj.AddComponent<MeshRenderer>();
         obj.AddComponent<MeshFilter>();
 
-        Mesh mesh = new Mesh();
-
-        // 頂点リストを作成
-        List<Vector3> vertices = new List<Vector3>();
-        List<Vector2> uvList = new List<Vector2>();
-
-        int i = 0;
-
         foreach (t_vertex t_Vertex in tVertexList)
         {
+            //頂点追加
             Vector3 vertex = new Vector3(t_Vertex.pos[0], t_Vertex.pos[1], t_Vertex.pos[2]);
             vertices.Add(vertex);
 
+            //UV追加
+            //note: mmdのUV座標のy座標はUnityで描画する場合 1 - uv.y
             Vector3 uv = new Vector3(t_Vertex.uv[0], 1 - t_Vertex.uv[1]);
-
             uvList.Add(uv);
         }
 
-        List<int> facevertList = new List<int>();
-        for(i = offsetPos; i < offsetPos + faceVertCount; i++)
+        //面情報リスト
+        for (faceVertIndex = offsetPos; faceVertIndex < offsetPos + faceVertCount; faceVertIndex++)
         {
-            facevertList.Add(face_vert_index[i]);
+            facevertList.Add(face_vert_index[faceVertIndex]);
         }
-        mesh.SetVertices(vertices);
-        //mesh.SetUVs(0, uvList);
-        mesh.uv = uvList.ToArray();
-        mesh.SetTriangles(facevertList, 0);
-        MeshFilter meshFilter = obj.GetComponent<MeshFilter>();
 
-        Texture J_SEIKAI01;
+        //頂点流し込み
+        mesh.SetVertices(vertices);
+        //uv情報流し込み
+        mesh.uv = uvList.ToArray();
+        //三角形描画
+        mesh.SetTriangles(facevertList, 0);
+
+        //テクスチャ生成
+        Texture texture;
         string fileName = textureName.Split('*')[0];
         fileName = fileName.Split('.')[0];
-        J_SEIKAI01 = Resources.Load("lat/"+fileName) as Texture;
+        texture = Resources.Load("lat/"+fileName) as Texture;
+        //テクスチャをmeshに貼り付け
         obj.GetComponent<Renderer>().material.shader = Shader.Find("Unlit/Texture");
-        obj.name = fileName;
-        obj.GetComponent<Renderer>().material.SetTexture("_MainTex", J_SEIKAI01);
+        obj.GetComponent<Renderer>().material.SetTexture("_MainTex", texture);
 
+        MeshFilter meshFilter = obj.GetComponent<MeshFilter>();
         meshFilter.mesh = mesh;
         meshFilter.mesh.RecalculateBounds();
+
+        //GameObjectの名前をいったん仮でマテリアル名にしておく
+        obj.name = fileName;
     }
 
 

--- a/New Unity Project/Assets/MMDLoader/MMDLoader.cs
+++ b/New Unity Project/Assets/MMDLoader/MMDLoader.cs
@@ -206,7 +206,7 @@ public class MMDLoader : MonoBehaviour
             Vector3 vertex = new Vector3(t_Vertex.pos[0], t_Vertex.pos[1], t_Vertex.pos[2]);
             vertices.Add(vertex);
 
-            Vector3 uv = new Vector3(t_Vertex.uv[0], t_Vertex.uv[1]);
+            Vector3 uv = new Vector3(t_Vertex.uv[0], 1 - t_Vertex.uv[1]);
 
             uvList.Add(uv);
         }
@@ -217,7 +217,8 @@ public class MMDLoader : MonoBehaviour
             facevertList.Add(face_vert_index[i]);
         }
         mesh.SetVertices(vertices);
-        mesh.SetUVs(0, uvList);
+        //mesh.SetUVs(0, uvList);
+        mesh.uv = uvList.ToArray();
         mesh.SetTriangles(facevertList, 0);
         MeshFilter meshFilter = obj.GetComponent<MeshFilter>();
 
@@ -230,6 +231,7 @@ public class MMDLoader : MonoBehaviour
         obj.GetComponent<Renderer>().material.SetTexture("_MainTex", J_SEIKAI01);
 
         meshFilter.mesh = mesh;
+        meshFilter.mesh.RecalculateBounds();
     }
 
 
@@ -250,6 +252,7 @@ public class MMDLoader : MonoBehaviour
             DrawMesh(offsetPos, (int)tMaterial.face_vert_count, new string(tMaterial.texture_file_name));
             offsetPos += (int)tMaterial.face_vert_count;
         }
+
     }
 
 }


### PR DESCRIPTION
- マテリアルの読み込み機能を実装しました。
マテリアルデータ構造は以下の通りです。
```
・材質リスト
DWORD material_count; // 材質数
t_material material[material_count]; // 材質データ(70Bytes/material)

・t_material
float diffuse_color[3]; // dr, dg, db // 減衰色
float alpha; // 減衰色の不透明度
float specularity;
float specular_color[3]; // sr, sg, sb // 光沢色
float mirror_color[3]; // mr, mg, mb // 環境色(ambient)
BYTE toon_index; // toon??.bmp // 0.bmp:0xFF, 1(01).bmp:0x00 ・・・ 10.bmp:0x09
BYTE edge_flag; // 輪郭、影
DWORD face_vert_count; // 面頂点数 // 面数ではありません。この材質で使う、面頂点リストのデータ数です。
char texture_file_name[20]; // テクスチャファイル名またはスフィアファイル名 // 20バイトぎりぎりまで使える(終端の0x00は無くても動く)
```

- マテリアルをメッシュに張り付ける処理を実装しました。
![uv座標反転](https://user-images.githubusercontent.com/10378512/103169610-a8352100-4880-11eb-9c60-9ea62800fd53.PNG)
